### PR TITLE
Setuptools fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     name='django-react-components',
     packages=find_packages(),
     url='https://github.com/zagaran/django-react-components',
-    version='0.1.8-alpha',
+    version='0.1.9-alpha',
 )


### PR DESCRIPTION
Removing setup.cfg.  

This file only included a single, deprecated keyword, `description-file`, which is incompatible with setuptools in two ways: first setuptools disallows dashes as of version 78.0.0 and second setuptools does not use that keyword.  

There are other tools that look for `description-file`, it is possible the keyword was included to support one of those tools,  but currently we do not use any of these(see https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#compatibility-with-other-tools for more context).  